### PR TITLE
Added Access Token and Refresh token to the authenticated Identity

### DIFF
--- a/Syncronex.Owin.Security.Syncaccess/Syncronex.Owin.Security.Syncaccess.nuspec
+++ b/Syncronex.Owin.Security.Syncaccess/Syncronex.Owin.Security.Syncaccess.nuspec
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?> 
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
-    <version>1.00</version>
+    <version>1.0.7</version>
     <authors>Syncronex, LLC</authors>
     <owners>Syncronex, LLC</owners>
     <id>Syncronex.owin.security.syncaccess</id>

--- a/Syncronex.Owin.Security.Syncaccess/src/Constants.cs
+++ b/Syncronex.Owin.Security.Syncaccess/src/Constants.cs
@@ -19,6 +19,9 @@ namespace Syncronex.Owin.Security.Syncaccess
         internal const string StageEnvironmentString = ".stage";
         internal const string ProdEnvironmentString = ""; // in production systems, the env portion of url is omitted
 
+        internal const string AccessTokenClaimType = "access_token";
+        internal const string RefreshTokenClaimType = "refresh_token";
+
         /// <summary>
         /// Uri template for making oAuth 'Authorization Code' request to the oAuth server
         /// </summary>

--- a/Syncronex.Owin.Security.Syncaccess/src/SyncaccessAuthenticatedContext.cs
+++ b/Syncronex.Owin.Security.Syncaccess/src/SyncaccessAuthenticatedContext.cs
@@ -17,11 +17,13 @@ namespace Syncronex.Owin.Security.Syncaccess
         /// <param name="context">Base OwinContext from which this object derives</param>
         /// <param name="account">Dynamic object representing the returned response from the IDP</param>
         /// <param name="accessToken">The access token that was used to fetch the account details.</param>
-        public SyncaccessAuthenticatedContext(IOwinContext context, JObject account, string accessToken)
+        /// <param name="refreshToken">The refresh token that was returned from the token endpoint call</param>
+        public SyncaccessAuthenticatedContext(IOwinContext context, JObject account, string accessToken, string refreshToken)
             : base(context)
         {
             Account = account;
             AccessToken = accessToken;
+            RefreshToken = refreshToken;
             AccountId = TryGetValue(account, Constants.SyncaccessAccountUniqueIdentifierKey);
             Email = TryGetValue(account, Constants.SyncaccessAccountEmailAddressKey);
         }
@@ -33,6 +35,10 @@ namespace Syncronex.Owin.Security.Syncaccess
         /// Get the access token that was used to fetch the account data
         /// </summary>
         public string AccessToken { get; private set; }
+        /// <summary>
+        /// Get the refresh token (if present) that was created during the auth code-for-token exchange
+        /// </summary>
+        public string RefreshToken { get; private set; }
         /// <summary>
         /// Gets the unique identifier used by the authorization server to identify the given
         /// account

--- a/TestDriver/App_Start/Startup.Auth.cs
+++ b/TestDriver/App_Start/Startup.Auth.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Web;
 using Microsoft.AspNet.Identity;
 using Owin;
@@ -18,9 +19,18 @@ namespace TestDriver
                 {
                     ClientId = "adm_sync_robcom_dev",
                     ClientSecret = "foobar88",
-                    TenantId = "sync_robcom_dev"
+                    TenantId = "sync_robcom_dev",
+                    Provider = new SyncaccessAuthenticationProvider()
+                    {
+                        OnAuthenticated = OnAuthenticated
+                    }
                 });
         }
 
+        private Task OnAuthenticated(SyncaccessAuthenticatedContext arg)
+        {
+            System.Diagnostics.Debug.WriteLine(arg.RefreshToken);
+            return Task.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
Needed these changes to allow us to capture the Access Token and Refresh Token in a way that persists on the client side.

The tokens are now added as specific claims to the authenticated identity.  that way, the calling application can fetch them from the ClaimsIdentity object and do whatever they need to with them.